### PR TITLE
SLING-7744: Allow Setting Suffix Resource

### DIFF
--- a/src/main/java/org/apache/sling/servlethelpers/MockRequestPathInfo.java
+++ b/src/main/java/org/apache/sling/servlethelpers/MockRequestPathInfo.java
@@ -33,6 +33,7 @@ public class MockRequestPathInfo implements RequestPathInfo {
     private String resourcePath;
     private String selectorString;
     private String suffix;
+    private Resource suffixResource;
 
     @Override
     public String getExtension() {
@@ -79,10 +80,13 @@ public class MockRequestPathInfo implements RequestPathInfo {
         this.suffix = suffix;
     }
 
-    // --- unsupported operations ---
+    public void setSuffixResource(final Resource suffixResource) {
+        this.suffixResource = suffixResource;
+    }
+
     @Override
     public Resource getSuffixResource() {
-        throw new UnsupportedOperationException();
+        return this.suffixResource;
     }
 
 }

--- a/src/test/java/org/apache/sling/servlethelpers/MockRequestPathInfoTest.java
+++ b/src/test/java/org/apache/sling/servlethelpers/MockRequestPathInfoTest.java
@@ -21,7 +21,10 @@ package org.apache.sling.servlethelpers;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 
+import org.apache.sling.api.resource.Resource;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -63,6 +66,14 @@ public class MockRequestPathInfoTest {
         assertNull(this.requestPathInfo.getSuffix());
         this.requestPathInfo.setSuffix("/suffix");
         assertEquals("/suffix", this.requestPathInfo.getSuffix());
+    }
+
+    @Test
+    public void testSuffixResource() {
+        assertNull(this.requestPathInfo.getSuffixResource());
+        Resource mockResource = mock(Resource.class);
+        this.requestPathInfo.setSuffixResource(mockResource);
+        assertSame(mockResource, this.requestPathInfo.getSuffixResource());
     }
 
 }


### PR DESCRIPTION
This patch will add the possibility to set the suffix resource in the
'MockRequestPathInfo' class. This allows the method
'getSuffixResource()' to actually return a resource instead of throwing
an exception.