### PR TITLE
Set the name when instantiating a MockRequestParameter

### DIFF
--- a/src/main/java/org/apache/sling/servlethelpers/MockRequestParameter.java
+++ b/src/main/java/org/apache/sling/servlethelpers/MockRequestParameter.java
@@ -36,6 +36,7 @@ class MockRequestParameter implements RequestParameter {
     private byte[] content;
 
     public MockRequestParameter(String name, String value) {
+        this.name = name;
         this.value = value;
         this.content = null;
     }


### PR DESCRIPTION
When using the MockSlingHttpServletRequest#setParameterMap then calling SlingHttpServletRequest#getRequestParameterList the name in each of the RequestParameter values is null.

This small PR should fix that to get the correct name.