### PR TITLE
SLING-11745 - Sling Mocks: allow setting parts for a request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam</artifactId>
             <version>${org.ops4j.pax.exam.version}</version>

--- a/src/main/java/org/apache/sling/servlethelpers/ByteArrayPart.java
+++ b/src/main/java/org/apache/sling/servlethelpers/ByteArrayPart.java
@@ -30,99 +30,99 @@ import javax.servlet.http.Part;
  *
  */
 public class ByteArrayPart implements Part {
-	
-	/**
-	 * Returns a <tt>Builder</tt> instance used to create a <tt>ByteArrayPart</tt> 
-	 * 
-	 * @return a new builder instance
-	 */
-	public static Builder builder() {
-		return new Builder();
-	}
-	
-	private final byte[] content;
-	private final String name;
-	
-	private ByteArrayPart(byte[] content, String name) {
-		if ( content == null )
-			throw new IllegalArgumentException("content may not be null");
-		
-		if ( name == null || name.isEmpty() )
-			throw new IllegalArgumentException("name may not be null or empty");
-		
-		this.content = content;
-		this.name = name;
-	}
 
-	@Override
-	public InputStream getInputStream() throws IOException {
-		return new ByteArrayInputStream(content);
-	}
+    /**
+     * Returns a <tt>Builder</tt> instance used to create a <tt>ByteArrayPart</tt> 
+     * 
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
 
-	@Override
-	public String getContentType() {
-		return null;
-	}
+    private final byte[] content;
+    private final String name;
 
-	@Override
-	public String getName() {
-		return name;
-	}
+    private ByteArrayPart(byte[] content, String name) {
+        if ( content == null )
+            throw new IllegalArgumentException("content may not be null");
 
-	@Override
-	public String getSubmittedFileName() {
-		return getName();
-	}
+        if ( name == null || name.isEmpty() )
+            throw new IllegalArgumentException("name may not be null or empty");
 
-	@Override
-	public long getSize() {
-		return content.length;
-	}
+        this.content = content;
+        this.name = name;
+    }
 
-	@Override
-	public void write(String fileName) throws IOException {
-		throw new UnsupportedOperationException();
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return new ByteArrayInputStream(content);
+    }
 
-	}
+    @Override
+    public String getContentType() {
+        return null;
+    }
 
-	@Override
-	public void delete() throws IOException {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public String getName() {
+        return name;
+    }
 
-	@Override
-	public String getHeader(String name) {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public String getSubmittedFileName() {
+        return getName();
+    }
 
-	@Override
-	public Collection<String> getHeaders(String name) {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public long getSize() {
+        return content.length;
+    }
 
-	@Override
-	public Collection<String> getHeaderNames() {
-		throw new UnsupportedOperationException();
-	}
-	
-	public static class Builder {
+    @Override
+    public void write(String fileName) throws IOException {
+        throw new UnsupportedOperationException();
 
-		private byte[] content;
-		private String name;
-		
-		public Builder withContent(byte[] content) {
-			this.content = content;
-			return this;
-		}
-		
-		public Builder withName(String name) {
-			this.name = name;
-			return this;
-		}
-		
-		public ByteArrayPart build() {
-			return new ByteArrayPart(content, name);
-		}
-	}
+    }
+
+    @Override
+    public void delete() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<String> getHeaders(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static class Builder {
+
+        private byte[] content;
+        private String name;
+
+        public Builder withContent(byte[] content) {
+            this.content = content;
+            return this;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public ByteArrayPart build() {
+            return new ByteArrayPart(content, name);
+        }
+    }
 
 }

--- a/src/main/java/org/apache/sling/servlethelpers/ByteArrayPart.java
+++ b/src/main/java/org/apache/sling/servlethelpers/ByteArrayPart.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.servlethelpers;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+import javax.servlet.http.Part;
+
+/**
+ * Simple <tt>Part</tt> implementation backed by an in-memory byte array
+ *
+ */
+public class ByteArrayPart implements Part {
+	
+	/**
+	 * Returns a <tt>Builder</tt> instance used to create a <tt>ByteArrayPart</tt> 
+	 * 
+	 * @return a new builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+	
+	private final byte[] content;
+	private final String name;
+	
+	private ByteArrayPart(byte[] content, String name) {
+		if ( content == null )
+			throw new IllegalArgumentException("content may not be null");
+		
+		if ( name == null || name.isEmpty() )
+			throw new IllegalArgumentException("name may not be null or empty");
+		
+		this.content = content;
+		this.name = name;
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return new ByteArrayInputStream(content);
+	}
+
+	@Override
+	public String getContentType() {
+		return null;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String getSubmittedFileName() {
+		return getName();
+	}
+
+	@Override
+	public long getSize() {
+		return content.length;
+	}
+
+	@Override
+	public void write(String fileName) throws IOException {
+		throw new UnsupportedOperationException();
+
+	}
+
+	@Override
+	public void delete() throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getHeader(String name) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Collection<String> getHeaders(String name) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Collection<String> getHeaderNames() {
+		throw new UnsupportedOperationException();
+	}
+	
+	public static class Builder {
+
+		private byte[] content;
+		private String name;
+		
+		public Builder withContent(byte[] content) {
+			this.content = content;
+			return this;
+		}
+		
+		public Builder withName(String name) {
+			this.name = name;
+			return this;
+		}
+		
+		public ByteArrayPart build() {
+			return new ByteArrayPart(content, name);
+		}
+	}
+
+}

--- a/src/main/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequest.java
+++ b/src/main/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequest.java
@@ -107,7 +107,7 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
     private Locale locale = Locale.US;
     private boolean getInputStreamCalled;
     private boolean getReaderCalled;
-    private List<Part> parts = new ArrayList<Part>();
+    private List<Part> parts = new ArrayList<>();
 
     private MockRequestDispatcherFactory requestDispatcherFactory;
     private String responseContentType;

--- a/src/main/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequest.java
+++ b/src/main/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequest.java
@@ -107,6 +107,7 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
     private Locale locale = Locale.US;
     private boolean getInputStreamCalled;
     private boolean getReaderCalled;
+    private List<Part> parts = new ArrayList<Part>();
 
     private MockRequestDispatcherFactory requestDispatcherFactory;
     private String responseContentType;
@@ -860,6 +861,25 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
     public RequestProgressTracker getRequestProgressTracker() {
         return new MockRequestProgressTracker();
     }
+    
+    public void addPart(Part part) {
+    	if ( part == null )
+    		throw new IllegalArgumentException("part may not be null");
+    	this.parts.add(part);
+    }
+    
+    @Override
+    public Collection<Part> getParts() {
+        return parts;
+    }
+
+    @Override
+    public Part getPart(String name) {
+        return parts.stream()
+			.filter( p -> p.getName().equals(name))
+			.findFirst()
+			.orElse(null);
+    }
 
     // --- unsupported operations ---
 
@@ -945,16 +965,6 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
 
     @Override
     public void logout() throws ServletException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Collection<Part> getParts() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Part getPart(String name) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequest.java
+++ b/src/main/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequest.java
@@ -82,7 +82,7 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
 
     private final ResourceResolver resourceResolver;
     private final RequestPathInfo requestPathInfo;
-    private Map<String, Object> attributeMap = new HashMap<String, Object>();
+    private Map<String, Object> attributeMap = new HashMap<>();
     private Map<String, MockRequestParameter[]> parameterMap = new LinkedHashMap<>();
     private HttpSession session;
     private Resource resource;
@@ -319,7 +319,7 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
     }
 
     private void parseQueryString(Map<String, MockRequestParameter[]> map, String query) throws UnsupportedEncodingException {
-        Map<String, List<String>> queryPairs = new LinkedHashMap<String, List<String>>();
+        Map<String, List<String>> queryPairs = new LinkedHashMap<>();
         String[] pairs = query.split("&");
         for (String pair : pairs) {
             int idx = pair.indexOf('=');
@@ -527,7 +527,7 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
 
     // part of Sling API 2.7
     public List<RequestParameter> getRequestParameterList() {
-        List<RequestParameter> params = new ArrayList<RequestParameter>();
+        List<RequestParameter> params = new ArrayList<>();
         for (RequestParameter[] requestParameters : getRequestParameterMap().values()) {
             params.addAll(Arrays.asList(requestParameters));
         }
@@ -861,13 +861,13 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
     public RequestProgressTracker getRequestProgressTracker() {
         return new MockRequestProgressTracker();
     }
-    
+
     public void addPart(Part part) {
-    	if ( part == null )
-    		throw new IllegalArgumentException("part may not be null");
-    	this.parts.add(part);
+        if ( part == null )
+            throw new IllegalArgumentException("part may not be null");
+        this.parts.add(part);
     }
-    
+
     @Override
     public Collection<Part> getParts() {
         return parts;
@@ -876,9 +876,9 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
     @Override
     public Part getPart(String name) {
         return parts.stream()
-			.filter( p -> p.getName().equals(name))
-			.findFirst()
-			.orElse(null);
+            .filter( p -> p.getName().equals(name))
+            .findFirst()
+            .orElse(null);
     }
 
     // --- unsupported operations ---

--- a/src/main/java/org/apache/sling/servlethelpers/package-info.java
+++ b/src/main/java/org/apache/sling/servlethelpers/package-info.java
@@ -19,5 +19,5 @@
 /**
  * Mock implementation of selected Servlet-related Sling APIs.
  */
-@org.osgi.annotation.versioning.Version("1.8")
+@org.osgi.annotation.versioning.Version("1.9")
 package org.apache.sling.servlethelpers;

--- a/src/test/java/org/apache/sling/servlethelpers/ByteArrayPartTest.java
+++ b/src/test/java/org/apache/sling/servlethelpers/ByteArrayPartTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.servlethelpers;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class ByteArrayPartTest {
+
+	private static final String TEST_CONTENT = "test input";
+	private static final String PART_NAME = "test_part_name";
+
+	@Test
+	public void buildPart() throws IOException {
+		ByteArrayPart part = ByteArrayPart.builder()
+			.withName(PART_NAME)
+			.withContent(TEST_CONTENT.getBytes(UTF_8))
+			.build();
+		
+		assertThat(part).as("part").isNotNull();
+		assertThat(part.getName()).as("part name").isEqualTo(PART_NAME);
+		assertThat(part.getInputStream()).as("part contents").hasContent(TEST_CONTENT);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void emptyBuilderFails() {
+		ByteArrayPart.builder().build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void missingNameFails() {
+		ByteArrayPart.builder().withContent(TEST_CONTENT.getBytes(UTF_8)).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void emptyNameFails() {
+		ByteArrayPart.builder().withName("").withContent(TEST_CONTENT.getBytes(UTF_8)).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void missingContentFails() {
+		ByteArrayPart.builder().withName("test").build();
+	}
+
+}

--- a/src/test/java/org/apache/sling/servlethelpers/ByteArrayPartTest.java
+++ b/src/test/java/org/apache/sling/servlethelpers/ByteArrayPartTest.java
@@ -27,39 +27,39 @@ import org.junit.Test;
 
 public class ByteArrayPartTest {
 
-	private static final String TEST_CONTENT = "test input";
-	private static final String PART_NAME = "test_part_name";
+    private static final String TEST_CONTENT = "test input";
+    private static final String PART_NAME = "test_part_name";
 
-	@Test
-	public void buildPart() throws IOException {
-		ByteArrayPart part = ByteArrayPart.builder()
-			.withName(PART_NAME)
-			.withContent(TEST_CONTENT.getBytes(UTF_8))
-			.build();
-		
-		assertThat(part).as("part").isNotNull();
-		assertThat(part.getName()).as("part name").isEqualTo(PART_NAME);
-		assertThat(part.getInputStream()).as("part contents").hasContent(TEST_CONTENT);
-	}
+    @Test
+    public void buildPart() throws IOException {
+        ByteArrayPart part = ByteArrayPart.builder()
+            .withName(PART_NAME)
+            .withContent(TEST_CONTENT.getBytes(UTF_8))
+            .build();
 
-	@Test(expected = IllegalArgumentException.class)
-	public void emptyBuilderFails() {
-		ByteArrayPart.builder().build();
-	}
+        assertThat(part).as("part").isNotNull();
+        assertThat(part.getName()).as("part name").isEqualTo(PART_NAME);
+        assertThat(part.getInputStream()).as("part contents").hasContent(TEST_CONTENT);
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void missingNameFails() {
-		ByteArrayPart.builder().withContent(TEST_CONTENT.getBytes(UTF_8)).build();
-	}
+    @Test(expected = IllegalArgumentException.class)
+    public void emptyBuilderFails() {
+        ByteArrayPart.builder().build();
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void emptyNameFails() {
-		ByteArrayPart.builder().withName("").withContent(TEST_CONTENT.getBytes(UTF_8)).build();
-	}
+    @Test(expected = IllegalArgumentException.class)
+    public void missingNameFails() {
+        ByteArrayPart.builder().withContent(TEST_CONTENT.getBytes(UTF_8)).build();
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void missingContentFails() {
-		ByteArrayPart.builder().withName("test").build();
-	}
+    @Test(expected = IllegalArgumentException.class)
+    public void emptyNameFails() {
+        ByteArrayPart.builder().withName("").withContent(TEST_CONTENT.getBytes(UTF_8)).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingContentFails() {
+        ByteArrayPart.builder().withName("test").build();
+    }
 
 }

--- a/src/test/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequestTest.java
+++ b/src/test/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequestTest.java
@@ -36,7 +36,6 @@ import java.io.BufferedReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
@@ -223,7 +222,7 @@ public class MockSlingHttpServletRequestTest {
         assertEquals("äöüß€!:!", request.getParameter("param2"));
         assertArrayEquals(new String[] { "a", "b" }, request.getParameterValues("param3"));
 
-        Map<String, Object> paramMap = new LinkedHashMap<String, Object>();
+        Map<String, Object> paramMap = new LinkedHashMap<>();
         paramMap.put("p1", "a");
         paramMap.put("p2", new String[] { "b", "c" });
         paramMap.put("p3", null);
@@ -542,32 +541,32 @@ public class MockSlingHttpServletRequestTest {
         String result2 = request.adaptTo(String.class);
         assertNotEquals(result1,  result2);
     }
-    
+
     @Test
     public void testNoParts() {
-    	assertThat(request.getParts()).as("request parts").isEmpty();
-    	assertThat(request.getPart("some-part")).as("missing part").isNull();
+        assertThat(request.getParts()).as("request parts").isEmpty();
+        assertThat(request.getPart("some-part")).as("missing part").isNull();
     }
-    
+
     @Test
     public void testExistingParts() {
-    	ByteArrayPart part = ByteArrayPart.builder()
-    			.withName("log.txt")
-    			.withContent("hello, world".getBytes(UTF_8))
-    			.build();
+        ByteArrayPart part = ByteArrayPart.builder()
+                .withName("log.txt")
+                .withContent("hello, world".getBytes(UTF_8))
+                .build();
 
-    	request.addPart(part);
-    	
-    	assertThat(request.getParts()).as("request parts")
-    		.hasSize(1)
-    		.extracting( p -> p.getName())
-    		.containsExactly("log.txt");
-    	
-    	assertThat(request.getPart("log.txt")).as("part looked up by name").isNotNull();
+        request.addPart(part);
+
+        assertThat(request.getParts()).as("request parts")
+            .hasSize(1)
+            .extracting( p -> p.getName())
+            .containsExactly("log.txt");
+
+        assertThat(request.getPart("log.txt")).as("part looked up by name").isNotNull();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidPart() {
-    	request.addPart(null);
+        request.addPart(null);
     }
 }

--- a/src/test/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequestTest.java
+++ b/src/test/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequestTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.servlethelpers;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -34,6 +36,7 @@ import java.io.BufferedReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
@@ -539,5 +542,32 @@ public class MockSlingHttpServletRequestTest {
         String result2 = request.adaptTo(String.class);
         assertNotEquals(result1,  result2);
     }
+    
+    @Test
+    public void testNoParts() {
+    	assertThat(request.getParts()).as("request parts").isEmpty();
+    	assertThat(request.getPart("some-part")).as("missing part").isNull();
+    }
+    
+    @Test
+    public void testExistingParts() {
+    	ByteArrayPart part = ByteArrayPart.builder()
+    			.withName("log.txt")
+    			.withContent("hello, world".getBytes(UTF_8))
+    			.build();
 
+    	request.addPart(part);
+    	
+    	assertThat(request.getParts()).as("request parts")
+    		.hasSize(1)
+    		.extracting( p -> p.getName())
+    		.containsExactly("log.txt");
+    	
+    	assertThat(request.getPart("log.txt")).as("part looked up by name").isNotNull();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidPart() {
+    	request.addPart(null);
+    }
 }


### PR DESCRIPTION
Allow setting parts on a MockSlingHttpServletRequest and provide a simple ByteArrayPart implementation.