### PR TITLE
SLING-11817 Implement MockSlingHttpServletRequest#getUserPrincipal

### DIFF
--- a/src/main/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequest.java
+++ b/src/main/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequest.java
@@ -881,6 +881,25 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
             .orElse(null);
     }
 
+    @Override
+    public Principal getUserPrincipal() {
+        Principal principal = null;
+        ResourceResolver rr = getResourceResolver();
+        if (rr != null) {
+            principal = rr.adaptTo(Principal.class);
+        }
+
+        if (principal == null) {
+            //fallback to the userid
+            final String userid = getRemoteUser();
+            if (userid != null) {
+                principal = () -> userid;
+            }
+        }
+
+        return principal;
+    }
+
     // --- unsupported operations ---
 
     @Override
@@ -890,11 +909,6 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
 
     @Override
     public String getRequestedSessionId() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Principal getUserPrincipal() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequestTest.java
+++ b/src/test/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequestTest.java
@@ -63,6 +63,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
@@ -579,6 +580,14 @@ public class MockSlingHttpServletRequestTest {
         Principal userPrincipal = request.getUserPrincipal();
         assertNotNull(userPrincipal);
         assertEquals("admin", userPrincipal.getName());
+    }
+    @Test
+    public void testGetUserPrincipalFromResourceResolver() {
+        Mockito.when(resourceResolver.adaptTo(Principal.class))
+            .thenReturn(() -> "rruser");
+        Principal userPrincipal = request.getUserPrincipal();
+        assertNotNull(userPrincipal);
+        assertEquals("rruser", userPrincipal.getName());
     }
 
 }

--- a/src/test/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequestTest.java
+++ b/src/test/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequestTest.java
@@ -36,6 +36,7 @@ import java.io.BufferedReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.security.Principal;
 import java.util.Calendar;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
@@ -569,4 +570,15 @@ public class MockSlingHttpServletRequestTest {
     public void testInvalidPart() {
         request.addPart(null);
     }
+
+    @Test
+    public void testGetUserPrincipal() {
+        assertNull(null, request.getUserPrincipal());
+
+        request.setRemoteUser("admin");
+        Principal userPrincipal = request.getUserPrincipal();
+        assertNotNull(userPrincipal);
+        assertEquals("admin", userPrincipal.getName());
+    }
+
 }


### PR DESCRIPTION
Add basic support for the MockSlingHttpServletRequest#getUserPrincipal API into the Servlet Helpers library.