### PR TITLE
SLING-11817 getUserPrincipal() should return null for anonymous requests

### DIFF
--- a/src/main/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequest.java
+++ b/src/main/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequest.java
@@ -884,15 +884,16 @@ public class MockSlingHttpServletRequest extends SlingAdaptable implements Sling
     @Override
     public Principal getUserPrincipal() {
         Principal principal = null;
-        ResourceResolver rr = getResourceResolver();
-        if (rr != null) {
-            principal = rr.adaptTo(Principal.class);
-        }
+        // always return null for anonymous user
+        final String userid = getRemoteUser();
+        if (userid != null) {
+            ResourceResolver rr = getResourceResolver();
+            if (rr != null) {
+                principal = rr.adaptTo(Principal.class);
+            }
 
-        if (principal == null) {
-            //fallback to the userid
-            final String userid = getRemoteUser();
-            if (userid != null) {
+            if (principal == null) {
+                //fallback to the userid
                 principal = () -> userid;
             }
         }

--- a/src/test/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequestTest.java
+++ b/src/test/java/org/apache/sling/servlethelpers/MockSlingHttpServletRequestTest.java
@@ -585,6 +585,11 @@ public class MockSlingHttpServletRequestTest {
     public void testGetUserPrincipalFromResourceResolver() {
         Mockito.when(resourceResolver.adaptTo(Principal.class))
             .thenReturn(() -> "rruser");
+        // always returns null for anonymous user
+        assertNull(request.getUserPrincipal());
+
+        // make remote user not anonymous
+        request.setRemoteUser("remoteuser");
         Principal userPrincipal = request.getUserPrincipal();
         assertNotNull(userPrincipal);
         assertEquals("rruser", userPrincipal.getName());


### PR DESCRIPTION
Keep the MockSlingHttpServletRequest#getUserPrincipal() implementation aligned with the real impl.

Compensates for changes done to SlingHttpServletRequestImpl from the sling engine in: SLING-11825