### PR TITLE
change commons-io dependency to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,13 +143,13 @@
             <version>4.1</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.7</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
The only references to commons-io classes are from unit tests, so the dependency should be changed to "test" scope